### PR TITLE
Optimize batch sync with PostgreSQL bulk operations

### DIFF
--- a/app/Http/Controllers/UnifiedSyncController.php
+++ b/app/Http/Controllers/UnifiedSyncController.php
@@ -70,7 +70,7 @@ class UnifiedSyncController extends Controller
                         $nodeChunkRequest->cookies->set($key, $value);
                     }
 
-                    $response = $nodeChunkController->targetedUpsert($nodeChunkRequest);
+                    $response = $nodeChunkController->bulkTargetedUpsert($nodeChunkRequest);
                     $results['nodes'] = json_decode($response->getContent(), true);
 
                     if (!($results['nodes']['success'] ?? false)) {

--- a/database/migrations/2025_12_12_134055_add_composite_indexes_to_nodes_table.php
+++ b/database/migrations/2025_12_12_134055_add_composite_indexes_to_nodes_table.php
@@ -1,0 +1,61 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * Creates composite unique indexes required for PostgreSQL UPSERT (ON CONFLICT)
+     * to work with bulk operations in DbNodeChunkController::bulkTargetedUpsert()
+     */
+    public function up(): void
+    {
+        // Drop existing single-column unique constraint if it exists
+        // (It's a constraint, not just an index)
+        DB::statement('ALTER TABLE nodes DROP CONSTRAINT IF EXISTS nodes_node_id_unique');
+
+        // Clean up duplicate (book, startLine) combinations before creating unique index
+        // Keep the record with the latest updated_at, delete older duplicates
+        DB::statement('
+            DELETE FROM nodes
+            WHERE id IN (
+                SELECT id FROM (
+                    SELECT id, ROW_NUMBER() OVER (
+                        PARTITION BY book, "startLine"
+                        ORDER BY updated_at DESC NULLS LAST, id DESC
+                    ) as rn
+                    FROM nodes
+                ) sub
+                WHERE rn > 1
+            )
+        ');
+
+        // Create composite unique index for (book, node_id) - PRIMARY lookup
+        // Partial index allows multiple NULL values for node_id
+        DB::statement('
+            CREATE UNIQUE INDEX nodes_book_node_id_unique
+            ON nodes (book, node_id)
+            WHERE node_id IS NOT NULL
+        ');
+
+        // Create composite unique index for (book, startLine) - FALLBACK lookup
+        DB::statement('
+            CREATE UNIQUE INDEX nodes_book_startline_unique
+            ON nodes (book, "startLine")
+        ');
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::statement('DROP INDEX IF EXISTS nodes_book_startline_unique');
+        DB::statement('DROP INDEX IF EXISTS nodes_book_node_id_unique');
+    }
+};


### PR DESCRIPTION
  PROBLEM:
  targetedUpsert() processed nodes one-by-one in a loop, causing
  300+ individual database queries for 150+ nodes. This made batch
  deletes and large syncs slow (~seconds to confirm).

  SOLUTION:
  Replace per-item loops with PostgreSQL bulk operations:
  - Batch deletes: Single DELETE ... WHERE IN query
  - Batch upserts: INSERT ... ON CONFLICT DO UPDATE (upsert)

  CHANGES:
  - Add bulkTargetedUpsert() method with batch operations
  - Add batchDelete(), batchUpsertByNodeId(), batchUpsertByStartLine() helpers
  - Create composite unique indexes: (book, node_id) and (book, startLine)
  - UnifiedSyncController now calls bulkTargetedUpsert()
  - Migration also cleans up 334 legacy duplicate records

  PERFORMANCE:
  Before: ~300+ queries for 192 nodes
  After:  2-3 queries for 192 nodes (~7ms total)

  Files:
  - app/Http/Controllers/DbNodeChunkController.php
  - app/Http/Controllers/UnifiedSyncController.php
  - database/migrations/2025_12_12_134055_add_composite_indexes_to_nodes_tabl e.php